### PR TITLE
update components:1.TextArea 2.TextField

### DIFF
--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -10,8 +10,9 @@ export interface ITextAreaProps extends Omit<BaseComponentProps, 'onChange'> {
   disabled?: boolean;
   readonly?: boolean;
   placeholder?: string;
-  resize: TextAreaResize;
+  resize?: TextAreaResize;
   value?: string;
+  defaultValue?: string;
   onChange?: (value: string) => void;
 }
 
@@ -100,6 +101,7 @@ const TextArea = ({
   disabled,
   readonly,
   value,
+  defaultValue,
   onChange,
   placeholder,
   resize,
@@ -127,7 +129,8 @@ const TextArea = ({
       <InputElm
         id={id}
         className='vscrui-TextArea__input'
-        defaultValue={inputValue}
+        value={inputValue}
+        defaultValue={defaultValue}
         placeholder={placeholder}
         data-resize={resize}
         disabled={disabled}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -9,6 +9,7 @@ export interface ITextFieldProps extends Omit<BaseComponentProps, 'onChange'> {
   readonly?: boolean;
   placeholder?: string;
   value?: string;
+  defaultValue?: string;
   onChange?: (value: string) => void;
 }
 
@@ -79,6 +80,7 @@ const TextField = ({
   disabled,
   readonly,
   value,
+  defaultValue,
   onChange,
   placeholder,
   ...rest
@@ -106,7 +108,8 @@ const TextField = ({
         type='text'
         id={id}
         className='vscrui-textfield__input'
-        defaultValue={inputValue}
+        value={inputValue}
+        defaultValue={defaultValue}
         placeholder={placeholder}
         disabled={disabled}
         readOnly={readonly}


### PR DESCRIPTION
Due to the fact that the **defaultValue** attribute of the input and textarea tags does not support two-way binding, it is more appropriate to use the **value** attribute to bind with the user's input value.

_Just like this Issue say 👉 #3_ 

The main changes in this PR include:

1. Providing an additional optional parameter value for the TextArea and TextField components. Component users can use this parameter for two-way binding (the defaultValue will continue to be retained as another optional parameter);

2. Making the resize parameter in TextArea optional.